### PR TITLE
add support for `start` and `end` props

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -7,9 +7,13 @@
 ## Usage
 
 ```js
-var code = require('{%= name %}');
-console.log(code('\n```js\nfoo\n```\n'));
-//=> {lang: 'js', code: 'foo', block: '\n```js\nfoo\n```\n'}
+var codeBlocks = require('{%= name %}');
+console.log(codeBlocks('usage\n```js\nvar qux = 123;\n```\nxyz'));
+//=> {lang: 'js', 
+//  code: 'var qux = 123;', 
+//  block: '```js\nvar qux = 123;\n```',
+//  start: 6,
+//  end: 30}
 ```
 
 ## Related projects

--- a/index.js
+++ b/index.js
@@ -11,11 +11,15 @@ var re = require('gfm-code-block-regex')();
 
 module.exports = function(str) {
   var arr = [];
-  while(re.exec(str)) {
+  var match = null
+
+  while (match = re.exec(str)) {
     arr.push({
-      lang: RegExp.$3,
-      code: RegExp.$5,
-      block: RegExp.$1
+      start: match.index,
+      end: match.index + match[1].length,
+      lang: match[3],
+      code: match[5],
+      block: match[1]
     });
   }
   return arr;

--- a/test.js
+++ b/test.js
@@ -26,16 +26,28 @@ describe('code block', function () {
   });
 
   it('should get a code block from a string.', function () {
-    var blocks = codeBlocks('\n```js\nfoo\n```\n');
+    var blocks = codeBlocks('```js\nfoo\n```');
     blocks[0].block.should.equal('```js\nfoo\n```');
     blocks[0].lang.should.equal('js');
     blocks[0].code.should.equal('foo');
+    blocks[0].start.should.equal(0);
+    blocks[0].end.should.equal(13);
   });
 
-  it('should get a code block from a string.', function () {
+  it('should get a code block from a string arounded with other data (text).', function () {
     var blocks = codeBlocks('abc\n```bash\nbar\n```\nxyz');
     blocks[0].block.should.equal('```bash\nbar\n```');
     blocks[0].lang.should.equal('bash');
     blocks[0].code.should.equal('bar');
+    blocks[0].start.should.equal(4);
+  });
+
+  it('should have position properties `start` and `end`.', function () {
+    var blocks = codeBlocks('usage\n```js\nvar qux = 123;\n```\nxyz');
+    blocks[0].block.should.equal('```js\nvar qux = 123;\n```');
+    blocks[0].lang.should.equal('js');
+    blocks[0].code.should.equal('var qux = 123;');
+    blocks[0].start.should.equal(6);
+    blocks[0].end.should.equal(30);
   });
 });


### PR DESCRIPTION
but when run latest verb-cli...

```
[01:28:48] using verbfile ~/.nvm/versions/io.js/v2.0.2/lib/node_modules/verb-cli/node_modules/verb-default/index.js
[01:28:48] starting 'default'
[01:28:48] finished 'default' after 68 ms

  ✔  helper-related: getting related projects from npm.
async-helper-base: {%= include("footer") %} error: %j TypeError: Cannot read property 'noreflinks' of undefined
```
